### PR TITLE
tests: fix imports and test collection under some environments

### DIFF
--- a/json_logging/framework/quart/__init__.py
+++ b/json_logging/framework/quart/__init__.py
@@ -12,7 +12,7 @@ from json_logging.util import is_not_match_any_pattern
 def is_quart_present():
     # noinspection PyPep8,PyBroadException
     try:
-        import quart
+        from quart import Quart
         return True
     except:
         return False

--- a/tests/smoketests/test_run_smoketest.py
+++ b/tests/smoketests/test_run_smoketest.py
@@ -26,7 +26,7 @@ def collect_backends():
         yield preset_backend
     else:
         for folder in Path(__file__).parent.iterdir():
-            if folder.is_dir():
+            if folder.is_dir() and folder.name != '__pycache__':
                 yield str(folder.name)
 
 


### PR DESCRIPTION
While packaging json-logging for NixOS, I've come across two issues with tests.  Since neither are specific to NixOS (though they may be an artifact of how the build environment is set up), I felt it'd be better to try to stream the fixes up.

- While testing, the import test for Quart finds not the 'quart' package, but `tests/smoketests/quart`.  It's been a while since I worked on this, but it seems to happen because pytest [prepends the test module directory to `sys.path` by default][1].  To make it work with a default pytest invocation, we can simply try to import something only the real quart package provides.
- If no smoketest backends are specified, it will try to find tests in a [`__pycache__` directory][2] if it exists.

[1]: https://docs.pytest.org/en/stable/pythonpath.html
[2]: https://www.python.org/dev/peps/pep-3147/