### PR TITLE
Move serialization function to the method of BaseJSONFormatter class

### DIFF
--- a/json_logging/__init__.py
+++ b/json_logging/__init__.py
@@ -19,7 +19,6 @@ if is_env_var_toggle("ENABLE_JSON_LOGGING"):
 ENABLE_JSON_LOGGING_DEBUG = False
 EMPTY_VALUE = '-'
 CREATE_CORRELATION_ID_IF_NOT_EXISTS = True
-JSON_SERIALIZER = lambda log: json.dumps(log, ensure_ascii=False)
 CORRELATION_ID_HEADERS = ['X-Correlation-ID', 'X-Request-ID']
 COMPONENT_ID = EMPTY_VALUE
 COMPONENT_NAME = EMPTY_VALUE
@@ -259,7 +258,7 @@ class BaseJSONFormatter(logging.Formatter):
 
     def format(self, record):
         log_object = self._format_log_object(record, request_util=_request_util)
-        return JSON_SERIALIZER(log_object)
+        return self._serialize(log_object)
 
     def _format_log_object(self, record, request_util):
         utcnow = datetime.utcnow()
@@ -269,6 +268,10 @@ class BaseJSONFormatter(logging.Formatter):
         }
         base_obj.update(self.base_object_common)
         return base_obj
+
+    @staticmethod
+    def _serialize(log_object):
+        return json.dumps(log_object, ensure_ascii=False)
 
 
 class JSONRequestLogFormatter(BaseJSONFormatter):

--- a/tests/smoketests/test_run_smoketest.py
+++ b/tests/smoketests/test_run_smoketest.py
@@ -34,7 +34,7 @@ def collect_backends():
 def test_api_example(backend):
     """For each of the examples start the API and see if the root endpoint is reachable"""
     api_process = subprocess.Popen(
-        [sys.executable, Path(__file__).parent / backend / "api.py"],
+        [sys.executable, str(os.path.join(Path(__file__).parent, backend, "api.py"))],
         stdout=sys.stdout,
         stderr=subprocess.STDOUT,
     )


### PR DESCRIPTION
In certain situations it's very handy to adjust serialization method preserving the rest of JSONFormetter's logic. 
For example replace default serialization (python's standard json lib) by some enhanced one (ujson, other).

So I moved function from global constant to the BaseJSONFormatter class' method.
Also added little fix for tests to be able to run on Windows