### PR TITLE
improve: convert unserializable attributes to str in JSON serializer

### DIFF
--- a/json_logging/__init__.py
+++ b/json_logging/__init__.py
@@ -20,7 +20,7 @@ if is_env_var_toggle("ENABLE_JSON_LOGGING"):
 ENABLE_JSON_LOGGING_DEBUG = False
 EMPTY_VALUE = '-'
 CREATE_CORRELATION_ID_IF_NOT_EXISTS = True
-JSON_SERIALIZER = lambda log: json.dumps(log, ensure_ascii=False)
+JSON_SERIALIZER = lambda log: json.dumps(log, ensure_ascii=False, default=str)
 CORRELATION_ID_HEADERS = ['X-Correlation-ID', 'X-Request-ID']
 COMPONENT_ID = EMPTY_VALUE
 COMPONENT_NAME = EMPTY_VALUE


### PR DESCRIPTION
This makes it possible to serialize e.g. `datetime` objects in `extra` logging.