### PR TITLE
Allow output field used for correlation_id to be customized

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Name | Description | Default value
  --- | --- | ---
 ENABLE_JSON_LOGGING | **
 DEPRECATED** Whether to enable JSON logging mode.Can be set as an environment variable, enable when set to to either one in following list (case-insensitive) **['true', '1', 'y', 'yes']** , this have no effect on request logger | false
+CORRELATION_ID_FIELD | Name of field in generated log messages containing the correlation-id value | 'correlation_id'
 CORRELATION_ID_HEADERS | List of HTTP headers that will be used to look for correlation-id value. HTTP headers will be searched one by one according to list order| ['X-Correlation-ID','X-Request-ID']
 EMPTY_VALUE | Default value when a logging record property is None |  '-'
 CORRELATION_ID_GENERATOR | function to generate unique correlation-id | uuid.uuid1

--- a/json_logging/__init__.py
+++ b/json_logging/__init__.py
@@ -12,6 +12,7 @@ from json_logging.framework_base import BaseRequestInfoExtractor, BaseResponseIn
     BaseFrameworkConfigurator
 from json_logging.util import get_library_logger, is_env_var_toggle
 
+CORRELATION_ID_FIELD = 'correlation_id'
 CORRELATION_ID_GENERATOR = uuid.uuid1
 ENABLE_JSON_LOGGING = False
 if is_env_var_toggle("ENABLE_JSON_LOGGING"):

--- a/json_logging/formatters.py
+++ b/json_logging/formatters.py
@@ -146,9 +146,9 @@ class JSONLogWebFormatter(JSONLogFormatter):
     def _format_log_object(self, record, request_util):
         json_log_object = super(JSONLogWebFormatter, self)._format_log_object(record, request_util)
 
-        if "correlation_id" not in json_log_object:
+        if json_logging.CORRELATION_ID_FIELD not in json_log_object:
             json_log_object.update({
-                "correlation_id": request_util.get_correlation_id(within_formatter=True),
+                json_logging.CORRELATION_ID_FIELD: request_util.get_correlation_id(within_formatter=True),
             })
 
         return json_log_object
@@ -172,7 +172,7 @@ class JSONRequestLogFormatter(BaseJSONFormatter):
 
         json_log_object.update({
             "type": "request",
-            "correlation_id": request_util.get_correlation_id(request),
+            json_logging.CORRELATION_ID_FIELD: request_util.get_correlation_id(request),
             "remote_user": request_adapter.get_remote_user(request),
             "request": request_adapter.get_path(request),
             "referer": request_adapter.get_http_header(request, 'referer', json_logging.EMPTY_VALUE),


### PR DESCRIPTION
The user-configurable names for correlation-id fields allow identifiers created by other analysis/tracing tools to be used as input. Making the output field configurable allows conforming on that end as well.