### PR TITLE
fix: wrap debug log when logger upated to using JSONLogFormatter

### DIFF
--- a/json_logging/__init__.py
+++ b/json_logging/__init__.py
@@ -127,7 +127,7 @@ def __init(framework_name=None, custom_formatter=None, enable_json=False):
     if ENABLE_JSON_LOGGING:
         logging._defaultFormatter = _default_formatter()
 
-        _logger.debug("Update all existing logger to using JSONLogFormatter")
+        ENABLE_JSON_LOGGING and _logger.debug("Update all existing logger to using JSONLogFormatter")
 
         existing_loggers = list(map(logging.getLogger, logging.Logger.manager.loggerDict))
         util.update_formatter_for_loggers(existing_loggers, _default_formatter)


### PR DESCRIPTION
Messages logged by the `__init()` function by the `json_logging logger` are generally wrapped in `ENABLE_JSON_LOGGING_DEBUG and ...` - apart from one log event -

https://github.com/bobbui/json-logging-python/blob/0e520ccafbabdd3cb2ee1e4a48e342df1fde8c95/json_logging/__init__.py#L130

This is the only message being logged by a scheduled job we have running that uses `json-logging-python`. This should only be logged if explicitly enabled via `ENABLE_JSON_LOGGING_DEBUG`.