### PR TITLE
fix: update utcnow for python 3.12 deprecation

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/json_logging/__init__.py
+++ b/json_logging/__init__.py
@@ -61,7 +61,6 @@ def config_root_logger():
     if ENABLE_JSON_LOGGING:
         ENABLE_JSON_LOGGING_DEBUG and _logger.debug("Update root logger to using JSONLogFormatter")
 
-        global _default_formatter
         util.update_formatter_for_loggers([logging.root], _default_formatter)
 
 

--- a/json_logging/dto.py
+++ b/json_logging/dto.py
@@ -32,14 +32,14 @@ class DefaultRequestResponseDTO(RequestResponseDTOBase):
 
     def __init__(self, request, **kwargs):
         super(DefaultRequestResponseDTO, self).__init__(request, **kwargs)
-        utcnow = datetime.now(timezone.utc).replace(tzinfo=None)
+        utcnow = datetime.now(timezone.utc)
         self._request_start = utcnow
         self["request_received_at"] = util.iso_time_format(utcnow)
 
     # noinspection PyAttributeOutsideInit
     def on_request_complete(self, response):
         super(DefaultRequestResponseDTO, self).on_request_complete(response)
-        utcnow = datetime.now(timezone.utc).replace(tzinfo=None)
+        utcnow = datetime.now(timezone.utc)
         time_delta = utcnow - self._request_start
         self["response_time_ms"] = int(time_delta.total_seconds()) * 1000 + int(time_delta.microseconds / 1000)
         self["response_sent_at"] = util.iso_time_format(utcnow)

--- a/json_logging/dto.py
+++ b/json_logging/dto.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from json_logging import util
 
@@ -32,14 +32,14 @@ class DefaultRequestResponseDTO(RequestResponseDTOBase):
 
     def __init__(self, request, **kwargs):
         super(DefaultRequestResponseDTO, self).__init__(request, **kwargs)
-        utcnow = datetime.utcnow()
+        utcnow = datetime.now(timezone.utc).replace(tzinfo=None)
         self._request_start = utcnow
         self["request_received_at"] = util.iso_time_format(utcnow)
 
     # noinspection PyAttributeOutsideInit
     def on_request_complete(self, response):
         super(DefaultRequestResponseDTO, self).on_request_complete(response)
-        utcnow = datetime.utcnow()
+        utcnow = datetime.now(timezone.utc).replace(tzinfo=None)
         time_delta = utcnow - self._request_start
         self["response_time_ms"] = int(time_delta.total_seconds()) * 1000 + int(time_delta.microseconds / 1000)
         self["response_sent_at"] = util.iso_time_format(utcnow)

--- a/json_logging/formatters.py
+++ b/json_logging/formatters.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 import traceback
-from datetime import datetime
+from datetime import datetime, timezone
 
 import json_logging
 
@@ -61,7 +61,7 @@ class BaseJSONFormatter(logging.Formatter):
         return json_logging.JSON_SERIALIZER(log_object)
 
     def _format_log_object(self, record, request_util):
-        utcnow = datetime.utcnow()
+        utcnow = datetime.now(timezone.utc).replace(tzinfo=None)
 
         base_obj = {
             "written_at": json_logging.util.iso_time_format(utcnow),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
 """Global fixtures and settings for the pytest test suite"""
 import sys
 import os
+from helpers import constants
 
 # Add test helper modules to search path with out making "tests" a Python package
 sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
+
+if sys.version_info.major > 3 or (sys.version_info.major == 3 and sys.version_info.minor >= 12):
+    constants.STANDARD_MSG_ATTRIBUTES.add('taskName')

--- a/tests/smoketests/sanic/requirements.txt
+++ b/tests/smoketests/sanic/requirements.txt
@@ -1,4 +1,4 @@
-sanic
+sanic==20.3.0
 requests
 pytest
 -e .


### PR DESCRIPTION
In python3.12 we get deprecation errors due to the use of 'naive' timestamps
from utcnow. (see https://github.com/python/cpython/issues/103857)

Replace with timezone.utc

See  https://github.com/python/cpython/issues/81669 

See https://blog.miguelgrinberg.com/post/it-s-time-for-a-change-datetime-utcnow-is-now-deprecated