### PR TITLE
fix: handle missing FastAPI request client

### DIFF
--- a/json_logging/framework/fastapi/implementation.py
+++ b/json_logging/framework/fastapi/implementation.py
@@ -111,10 +111,14 @@ class FastAPIRequestInfoExtractor(BaseRequestInfoExtractor):
         return request.method
 
     def get_remote_ip(self, request: starlette.requests.Request):
-        return request.client.host
+        if request.client:
+            return request.client.host
+        return json_logging.EMPTY_VALUE
 
     def get_remote_port(self, request: starlette.requests.Request):
-        return request.client.port
+        if request.client:
+            return request.client.port
+        return json_logging.EMPTY_VALUE
 
 
 class FastAPIResponseInfoExtractor(BaseResponseInfoExtractor):

--- a/json_logging/framework/fastapi/implementation.py
+++ b/json_logging/framework/fastapi/implementation.py
@@ -111,12 +111,12 @@ class FastAPIRequestInfoExtractor(BaseRequestInfoExtractor):
         return request.method
 
     def get_remote_ip(self, request: starlette.requests.Request):
-        if request.client:
+        if request.client is not None:
             return request.client.host
         return json_logging.EMPTY_VALUE
 
     def get_remote_port(self, request: starlette.requests.Request):
-        if request.client:
+        if request.client is not None:
             return request.client.port
         return json_logging.EMPTY_VALUE
 

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -215,3 +215,22 @@ def test_excluded_from_request_instrumentation(client_and_log_handler):
 
     assert response.status_code == 200
     assert len(handler.messages) == 0
+
+
+def test_request_info_extractor_handles_missing_client():
+    """Test if missing request client information falls back to empty values"""
+    import json_logging
+    from json_logging.framework.fastapi.implementation import FastAPIRequestInfoExtractor
+
+    request = fastapi.Request({
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [],
+        "query_string": b"",
+        "client": None,
+    })
+    extractor = FastAPIRequestInfoExtractor()
+
+    assert extractor.get_remote_ip(request) == json_logging.EMPTY_VALUE
+    assert extractor.get_remote_port(request) == json_logging.EMPTY_VALUE


### PR DESCRIPTION
## Summary
- Handles FastAPI/Starlette requests where `request.client` is `None`.
- Returns the library empty value for missing remote IP and port instead of raising `AttributeError`.
- Adds a regression test for the missing-client case.

Fixes #90

## Verification
- `python -m pytest tests/test_fastapi.py`
- `python -m pytest --ignore tests/smoketests`
- `python -m flake8 json_logging/framework/fastapi/implementation.py tests/test_fastapi.py --count --select=E9,F63,F7,F82 --show-source --statistics`

## Notes
- The broader CI-style exit-zero flake8 report still shows pre-existing warnings outside this change path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of FastAPI request information extraction to gracefully handle cases where client details are unavailable, preventing logging failures.
  * Remote IP and remote port now return an empty value when request client information is missing.

* **Tests**
  * Added test coverage for missing client information scenarios to verify remote IP/port fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->