### PR TITLE
docs: correct NOTICE attribution

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,4 @@
 json-logging-python
 
-Copyright 2017 Bob T. and json-logging contributors
-
-This product includes software developed for the json-logging-python project.
+Copyright 2017 Bob T.
+Copyright 2017 json-logging contributors


### PR DESCRIPTION
## Summary
- Replace the custom NOTICE attribution text from #117 with standard project-specific attribution lines.
- Use separate copyright lines for Bob T. and json-logging contributors with the 2017 date suggested in #93.
- Keep the packaging metadata from #117 intact so NOTICE remains included in source distributions.

Follow-up to #117.
Refs #93.

## Verification
- `/tmp/json-logging-python-venv-followup/bin/python setup.py check -m -s`
- `/tmp/json-logging-python-venv-followup/bin/python -m pytest --ignore tests/smoketests` (23 passed)
- `/tmp/json-logging-python-venv-followup/bin/python setup.py sdist --dist-dir /tmp/json-logging-python-sdist-followup` and `tar -tzf /tmp/json-logging-python-sdist-followup/json_logging-1.5.1.tar.gz | grep '/NOTICE$'`
- `/tmp/json-logging-python-venv-followup/bin/python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` returned `0`

## Notes
- This removes the custom inferred wording from #117 without duplicating Apache license boilerplate that already lives in `LICENSE`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the NOTICE file’s copyright attribution by splitting the combined copyright line into two separate lines.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->